### PR TITLE
Make "Test multi grid support" support margins around grids

### DIFF
--- a/src/grid/mod.rs
+++ b/src/grid/mod.rs
@@ -5,9 +5,9 @@ use std::{fmt::Debug, io::BufRead};
 
 pub trait Grid: Debug {
     fn bands(&self) -> usize;
-    fn contains(&self, coord: &Coor4D) -> bool;
+    fn contains(&self, coord: &Coor4D, within: f64) -> bool;
     ///  Returns `None` if the grid or any of it's sub-grids do not contain the point.
-    fn interpolation(&self, coord: &Coor4D) -> Option<Coor4D>;
+    fn interpolation(&self, coord: &Coor4D, within: f64) -> Option<Coor4D>;
 }
 
 /// Grid characteristics and interpolation.
@@ -41,15 +41,18 @@ impl Grid for BaseGrid {
 
     /// Determine whether a given coordinate falls within the grid borders.
     /// "On the border" qualifies as within.
-    fn contains(&self, position: &Coor4D) -> bool {
+    fn contains(&self, position: &Coor4D, within: f64) -> bool {
         // We start by assuming that the last row (latitude) is the southernmost
         let mut min = self.lat_1;
         let mut max = self.lat_0;
+
         // If it's not, we swap
         if self.dlat > 0. {
             (min, max) = (max, min)
         }
-        if position[1] != position[1].clamp(min, max) {
+
+        let grace = within * self.dlat.abs();
+        if position[1] != position[1].clamp(min - grace, max + grace) {
             return false;
         }
 
@@ -60,7 +63,9 @@ impl Grid for BaseGrid {
         if self.dlon < 0. {
             (min, max) = (max, min)
         }
-        if position[0] != position[0].clamp(min, max) {
+
+        let grace = within * self.dlon.abs();
+        if position[0] != position[0].clamp(min - grace, max + grace) {
             return false;
         }
 
@@ -73,8 +78,8 @@ impl Grid for BaseGrid {
     // It is, however, one of the cases where a more extensive use of abstractions
     // leads to a significantly larger code base, much harder to maintain and
     // comprehend.
-    fn interpolation(&self, coord: &Coor4D) -> Option<Coor4D> {
-        if !self.contains(coord) {
+    fn interpolation(&self, coord: &Coor4D, within: f64) -> Option<Coor4D> {
+        if !self.contains(coord, within) {
             return None;
         };
 
@@ -325,18 +330,19 @@ mod tests {
         let geoid = BaseGrid::plain(&geoid_header, Some(&geoid_grid), None)?;
 
         let c = Coor4D::geo(58.75, 08.25, 0., 0.);
-        assert_eq!(geoid.contains(&c), false);
+        assert_eq!(geoid.contains(&c, 0.0), false);
+        assert_eq!(geoid.contains(&c, 1.0), true);
 
-        let n = geoid.interpolation(&c).unwrap();
+        let n = geoid.interpolation(&c, 1.0).unwrap();
         assert!((n[0] - 58.83).abs() < 0.1);
 
-        let d = datum.interpolation(&c).unwrap();
+        let d = datum.interpolation(&c, 1.0).unwrap();
         assert!(c.default_ellps_dist(&d.to_arcsec().to_radians()) < 1.0);
 
         // Extrapolation
         let c = Coor4D::geo(100., 50., 0., 0.);
         // ...with output converted back to arcsec
-        let d = datum.interpolation(&c).unwrap().to_arcsec();
+        let d = datum.interpolation(&c, 100.0).unwrap().to_arcsec();
 
         // The grid is constructed to make the position in degrees equal to
         // the extrapolation value in arcsec.
@@ -349,9 +355,9 @@ mod tests {
         // Interpolation
         let c = Coor4D::geo(55.06, 12.03, 0., 0.);
         // Check that we're not extrapolating
-        assert_eq!(datum.contains(&c), true);
+        assert_eq!(datum.contains(&c, 0.0), true);
         // ...with output converted back to arcsec
-        let d = datum.interpolation(&c).unwrap().to_arcsec();
+        let d = datum.interpolation(&c, 0.0).unwrap().to_arcsec();
         // We can do slightly better for interpolation than for extrapolation,
         // but the grid values are f32, so we have only approx 7 significant
         // figures...


### PR DESCRIPTION
Since the extended search margin is needed for the inverse cases anyway, we might as well implement them now.

This adds another parameter to the `contains` and `interpolation` methods, the margin given in grid cell units.

The grid search stuff has been enriched with another nested loop, making the search run first with no margin, then with a half-cell margin. It may later show that this should actually be one half and one (due to the grid-vs.-image, point-vs.-block support stuff).

I hope I have this PR organized the right way round - the intention is that @Rennzie  should accept this one, which would update your PR against my repo, we will run the tests, they will succeed, and I will merge